### PR TITLE
Remove obsoleted option from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ A GitHub Action to send a workflow result to a Slack channel.
   if: always()
   uses: dojineko/slack-notify@v1
   with:
-    github_host: github.private.test # default: github.com
     job_status: ${{ job.status }}
     slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
 ```
@@ -20,7 +19,6 @@ A GitHub Action to send a workflow result to a Slack channel.
 
 Variables | Default | Purpose
 ---- | ---- | ----
-github_host | github.com | Specifies the hostname for GitHub, for GitHub Enterprise.
 job_status | (required) | Job status
 slack_webhook | (required) | Slack Incomming Webhook (legacy token is not supported)
 channel | (option) | The name of the channel that the user selected as a destination for webhook messages.


### PR DESCRIPTION
`github_host` option appears to be obsoleted.

- ref: https://github.com/dojineko/slack-notify/pull/2