### PR TITLE
Use Node16 because Node12 is deprecated.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,5 +17,5 @@ inputs:
     description: Suffix to be added if the job fails. (e.g. <@user_id> <!subteam^user_group_id> <!here>
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Hi, @dojineko san! 
Since Node12 is now deprecated in GitHub Actions, I suggest using Node16.

I referred to this article.
[GitHub Actions: All Actions will begin running on Node16 instead of Node12 | GitHub Changelog](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)

Also, would you consider creating a tag such as v2?

Thanks. 😃 